### PR TITLE
Removes TG-salt code

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/bus.dmm
+++ b/_maps/RandomRuins/SpaceRuins/bus.dmm
@@ -50,7 +50,6 @@
 /area/ruin/unpowered/no_grav)
 "al" = (
 /obj/effect/decal/cleanable/salt,
-/obj/item/reagent_containers/food/condiment/saltshaker,
 /turf/open/floor/plating/asteroid/airless,
 /area/ruin/unpowered/no_grav)
 "am" = (
@@ -174,7 +173,6 @@
 /area/ruin/unpowered/no_grav)
 "aC" = (
 /obj/structure/fluff/bus/passable,
-/obj/item/reagent_containers/food/condiment/saltshaker,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/airless/dark{
 	icon_state = "bus"

--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -504,10 +504,6 @@
 "ba" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/peppermill,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = 4;
-	pixel_y = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
 	dir = 9
 	},

--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -3434,10 +3434,6 @@
 	pixel_x = 5;
 	pixel_y = -2
 	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -2;
-	pixel_y = 2
-	},
 /turf/open/floor/plasteel/cafeteria,
 /area/ruin/space/has_grav/ancientstation/kitchen)
 "iM" = (

--- a/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -2554,9 +2554,6 @@
 /area/ruin/space/has_grav/hotel/bar)
 "gY" = (
 /obj/structure/table/wood,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = 4
-	},
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = -4
 	},
@@ -2739,9 +2736,6 @@
 /turf/open/floor/plasteel/freezer,
 /area/ruin/space/has_grav/hotel/bar)
 "hx" = (
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = 4
-	},
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = -4
 	},

--- a/_maps/RandomZLevels/centcomAway.dmm
+++ b/_maps/RandomZLevels/centcomAway.dmm
@@ -310,7 +310,6 @@
 "bg" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/peppermill,
-/obj/item/reagent_containers/food/condiment/saltshaker,
 /turf/open/floor/plasteel/green{
 	dir = 1
 	},
@@ -3736,7 +3735,6 @@
 "mL" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/peppermill,
-/obj/item/reagent_containers/food/condiment/saltshaker,
 /turf/open/floor/plasteel/red,
 /area/awaymission/centcomAway/cafe)
 "mM" = (

--- a/_maps/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/RandomZLevels/moonoutpost19.dmm
@@ -4810,9 +4810,6 @@
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = 3
 	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3
-	},
 /obj/machinery/door/poddoor/shutters{
 	id = "awaykitchen";
 	name = "Serving Hatch"

--- a/_maps/RandomZLevels/spacebattle.dmm
+++ b/_maps/RandomZLevels/spacebattle.dmm
@@ -1374,7 +1374,6 @@
 /area/awaymission/spacebattle/cruiser)
 "eU" = (
 /obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/condiment/saltshaker,
 /turf/open/floor/plasteel/bar,
 /area/awaymission/spacebattle/cruiser)
 "eV" = (

--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -3567,9 +3567,6 @@
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "hR" = (
 /obj/structure/table,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3
-	},
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = 3
 	},
@@ -5768,9 +5765,6 @@
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "lT" = (
 /obj/structure/table,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3
-	},
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = 3
 	},

--- a/_maps/RandomZLevels/wildwest.dmm
+++ b/_maps/RandomZLevels/wildwest.dmm
@@ -748,7 +748,6 @@
 /area/awaymission/wildwest/mines)
 "cK" = (
 /obj/structure/table/wood,
-/obj/item/reagent_containers/food/condiment/saltshaker,
 /turf/open/floor/wood,
 /area/awaymission/wildwest/mines)
 "cL" = (

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -18952,9 +18952,6 @@
 /area/maintenance/port)
 "aVD" = (
 /obj/structure/table,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3
-	},
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = 3
 	},
@@ -33898,10 +33895,6 @@
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = 5;
 	pixel_y = -2
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -2;
-	pixel_y = 2
 	},
 /turf/open/floor/plasteel/bar,
 /area/crew_quarters/bar)
@@ -52700,9 +52693,6 @@
 /area/maintenance/port/aft)
 "cAE" = (
 /obj/structure/table/glass,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_y = 2
-	},
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = 2
 	},
@@ -56655,10 +56645,6 @@
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = 3;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3;
 	pixel_y = 4
 	},
 /obj/effect/decal/cleanable/dirt{

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -4748,10 +4748,6 @@
 /area/maintenance/starboard/fore)
 "ajQ" = (
 /obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -8;
-	pixel_y = 5
-	},
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = -8
 	},
@@ -19185,10 +19181,6 @@
 /turf/open/floor/plasteel/redyellow,
 /area/crew_quarters/bar/atrium)
 "aOK" = (
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -8;
-	pixel_y = 5
-	},
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = -8
 	},
@@ -25979,10 +25971,6 @@
 	id = "kitchencounter";
 	name = "Kitchen Counter Shutters"
 	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -8;
-	pixel_y = 5
-	},
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = -8
 	},
@@ -30431,10 +30419,6 @@
 /area/crew_quarters/kitchen)
 "blA" = (
 /obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -8;
-	pixel_y = 5
-	},
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = -8
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -586,10 +586,6 @@
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = 3
 	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3;
-	pixel_y = 5
-	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "abG" = (
@@ -37987,9 +37983,6 @@
 /area/crew_quarters/bar)
 "bAn" = (
 /obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3
-	},
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = 3
 	},
@@ -42596,9 +42589,6 @@
 	id = "kitchen";
 	name = "Serving Hatch"
 	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3
-	},
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = 3
 	},
@@ -46164,9 +46154,6 @@
 /area/crew_quarters/kitchen)
 "bRS" = (
 /obj/structure/table,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3
-	},
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = 3
 	},
@@ -73878,10 +73865,6 @@
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = 3;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3;
 	pixel_y = 4
 	},
 /obj/effect/decal/cleanable/dirt{

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -11109,10 +11109,6 @@
 	},
 /area/crew_quarters/bar/atrium)
 "auc" = (
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -8;
-	pixel_y = 5
-	},
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = -8
 	},
@@ -14381,10 +14377,6 @@
 /turf/open/floor/plasteel/redyellow,
 /area/crew_quarters/bar/atrium)
 "aAP" = (
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -8;
-	pixel_y = 5
-	},
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = -8
 	},
@@ -15900,10 +15892,6 @@
 	id = "kitchencounter";
 	name = "Kitchen Counter Shutters"
 	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -8;
-	pixel_y = 5
-	},
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = -8
 	},
@@ -16546,10 +16534,6 @@
 /area/crew_quarters/kitchen)
 "aFc" = (
 /obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -8;
-	pixel_y = 5
-	},
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = -8
 	},
@@ -17444,10 +17428,6 @@
 /turf/open/floor/plasteel/redyellow,
 /area/crew_quarters/bar/atrium)
 "aGO" = (
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -8;
-	pixel_y = 5
-	},
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = -8
 	},

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -20773,11 +20773,6 @@
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 32
 	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	layer = 3;
-	pixel_x = -2;
-	pixel_y = 2
-	},
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = 5;
 	pixel_y = -2
@@ -21716,10 +21711,6 @@
 /area/crew_quarters/kitchen)
 "bbh" = (
 /obj/structure/table,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = 4;
-	pixel_y = 4
-	},
 /obj/item/reagent_containers/food/condiment/peppermill,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
@@ -46242,10 +46233,6 @@
 /area/chapel/main/monastery)
 "chW" = (
 /obj/structure/table,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = 3;
-	pixel_y = 4
-	},
 /obj/item/reagent_containers/food/condiment/peppermill,
 /obj/item/storage/box/ingredients/wildcard{
 	layer = 3.1
@@ -46483,11 +46470,6 @@
 /area/chapel/main/monastery)
 "ciO" = (
 /obj/structure/table/wood,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	layer = 3.1;
-	pixel_x = -2;
-	pixel_y = 2
-	},
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = 5;
 	pixel_y = 6

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -12732,10 +12732,6 @@
 /area/tdome/tdomeobserve)
 "Ho" = (
 /obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -8;
-	pixel_y = 5
-	},
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = -8
 	},
@@ -12914,10 +12910,6 @@
 "HK" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -8;
-	pixel_y = 5
-	},
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = -8
 	},

--- a/_maps/shuttles/whiteship_meta.dmm
+++ b/_maps/shuttles/whiteship_meta.dmm
@@ -849,10 +849,6 @@
 	pixel_x = 3;
 	pixel_y = 4
 	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3;
-	pixel_y = 4
-	},
 /obj/effect/decal/cleanable/dirt{
 	desc = "A thin layer of dust coating the floor.";
 	name = "dust"

--- a/code/modules/food_and_drinks/food/condiment.dm
+++ b/code/modules/food_and_drinks/food/condiment.dm
@@ -116,44 +116,6 @@
 	desc = "Tasty spacey sugar!"
 	list_reagents = list("sugar" = 50)
 
-/obj/item/reagent_containers/food/condiment/saltshaker		//Separate from above since it's a small shaker rather then
-	name = "salt shaker"											//	a large one.
-	desc = "Salt. From space oceans, presumably."
-	icon_state = "saltshakersmall"
-	possible_transfer_amounts = list(1,20) //for clown turning the lid off
-	amount_per_transfer_from_this = 1
-	volume = 20
-	list_reagents = list("sodiumchloride" = 20)
-	possible_states = list()
-
-/obj/item/reagent_containers/food/condiment/saltshaker/on_reagent_change(changetype)
-	if(reagents.reagent_list.len == 0)
-		icon_state = "emptyshaker"
-	else
-		icon_state = "saltshakersmall"
-
-/obj/item/reagent_containers/food/condiment/saltshaker/suicide_act(mob/user)
-	user.visible_message("<span class='suicide'>[user] begins to swap forms with the salt shaker! It looks like [user.p_theyre()] trying to commit suicide!</span>")
-	var/newname = "[name]"
-	name = "[user.name]"
-	user.name = newname
-	user.real_name = newname
-	desc = "Salt. From dead crew, presumably."
-	return (TOXLOSS)
-
-/obj/item/reagent_containers/food/condiment/saltshaker/afterattack(obj/target, mob/living/user, proximity)
-	if(!proximity)
-		return
-	if(isturf(target))
-		if(!reagents.has_reagent("sodiumchloride", 2))
-			to_chat(user, "<span class='warning'>You don't have enough salt to make a pile!</span>")
-			return
-		user.visible_message("<span class='notice'>[user] shakes some salt onto [target].</span>", "<span class='notice'>You shake some salt onto [target].</span>")
-		reagents.remove_reagent("sodiumchloride", 2)
-		new/obj/effect/decal/cleanable/salt(target)
-		return
-	..()
-
 /obj/item/reagent_containers/food/condiment/peppermill
 	name = "pepper mill"
 	desc = "Often used to flavor food or make people sneeze."


### PR DESCRIPTION
:cl: 
del: /tg/ salt-code has been removed!
/:cl:

[why]: # Neri was complaining in Maintainer-bus that they wanted to remove tg-salt code, so here you go!
