### PR TITLE
Adds mindslaves

### DIFF
--- a/code/datums/uplink_items.dm
+++ b/code/datums/uplink_items.dm
@@ -1157,6 +1157,13 @@ GLOBAL_LIST_EMPTY(uplink_items) // Global list so we only initialize this once.
 	cost = 20
 	include_modes = list(/datum/game_mode/nuclear)
 
+//HAVEN start - Mindslave implant
+/datum/uplink_item/implants/mindslave
+	name = "Mindslave Implant"
+	desc = "An implant injected into a targets body. Will cause the target to obey your every command whilst the target is implanted. Implant can be removed by surgery!"
+	item = /obj/item/storage/box/syndie_kit/imp_mindslave
+	cost = 12
+//HAVEN end
 
 // Cybernetics
 /datum/uplink_item/cyber_implants

--- a/code/game/objects/items/implants/implant.dm
+++ b/code/game/objects/items/implants/implant.dm
@@ -9,6 +9,7 @@
 	var/allow_multiple = FALSE
 	var/uses = -1
 	flags_1 = DROPDEL_1
+	var/implant_time = 50 //HAVEN - The amount of time it takes to implant the implant
 
 
 /obj/item/implant/proc/trigger(emote, mob/living/carbon/source)

--- a/code/game/objects/items/implants/implant_loyality.dm
+++ b/code/game/objects/items/implants/implant_loyality.dm
@@ -20,13 +20,18 @@
 	if(..())
 		if(!target.mind)
 			return TRUE
+		//HAVEN START - Mindslave removal
+		var/obj/item/implant/mindslave/imp = locate(/obj/item/implant/mindslave) in target
+		if(imp)
+			imp.removed(target)
+		//HAVEN END
 		if(target.mind.has_antag_datum(/datum/antagonist/rev/head) || target.mind.unconvertable)
 			if(!silent)
 				target.visible_message("<span class='warning'>[target] seems to resist the implant!</span>", "<span class='warning'>You feel something interfering with your mental conditioning, but you resist it!</span>")
 			removed(target, 1)
 			qdel(src)
 			return FALSE
-		
+
 		var/datum/antagonist/rev/rev = target.mind.has_antag_datum(/datum/antagonist/rev)
 		if(rev)
 			rev.remove_revolutionary(FALSE, user)

--- a/code/game/objects/items/implants/implanter.dm
+++ b/code/game/objects/items/implants/implanter.dm
@@ -29,7 +29,7 @@
 			M.visible_message("<span class='warning'>[user] is attempting to implant [M].</span>")
 
 		var/turf/T = get_turf(M)
-		if(T && (M == user || do_mob(user, M, 50)))
+		if(T && (M == user || do_mob(user, M, imp.implant_time))) //HAVEN - Replaced 50 with imp.implant_time, to allow for implant-dependent implanttimes
 			if(src && imp)
 				if(imp.implant(M, user))
 					if (M == user)

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -305,3 +305,14 @@
 /obj/item/storage/box/syndie_kit/mimery/PopulateContents()
 	new /obj/item/spellbook/oneuse/mimery_blockade(src)
 	new /obj/item/spellbook/oneuse/mimery_guns(src)
+
+/obj/item/storage/box/syndie_kit/imp_mindslave
+	name = "boxed mindslave implant (with injector)"
+
+/obj/item/storage/box/syndie_kit/imp_mindslave/New()
+	..()
+	var/obj/item/implanter/O = new(src)
+	var/obj/item/implant/mindslave/imp = new /obj/item/implant/mindslave(O)
+	O.imp = imp
+	O.update_icon()
+	return

--- a/haven/changes.md
+++ b/haven/changes.md
@@ -7,7 +7,7 @@ The best practice to have while coding is to keep everything modularized, or the
 ## List of edits
 
 ### Example change
-ExampleProc() in /repo/ExampleTGFile.dm 
+ExampleProc() in /repo/ExampleTGFile.dm
 Example change description
 Example icon change
 
@@ -17,3 +17,7 @@ haven_initialize() in code/game/world.dm
 ### Polychromic Clothes Spawning in Mixed Wardrobes
 /obj/structure/closet/wardrobe/mixed/PopulateContents() in code/game/objects/structures/crates_lockers/closets/wardrobe.dm
 This simply replaces the jumpsuits that normally spawn in hte mixed wardrobe to be replaced by a sample of polychromic clothes.
+
+###Removal of mindslave implant
+imp.removed(target) in /code/game/objects/items/implants/implant_loyality.dm
+Triggers the removal effects of the mindslave implant

--- a/haven/code/game/objects/items/implants/implant_mindslave.dm
+++ b/haven/code/game/objects/items/implants/implant_mindslave.dm
@@ -1,0 +1,75 @@
+/obj/item/implant/mindslave
+	name = "mindslave implant"
+	desc = "Turn a crewmate into your eternal slave"
+	activated = 0
+	implant_time = 300
+
+/obj/item/implant/mindslave/get_data()
+	var/dat = {"
+<b>Implant Specifications:</b><BR>
+<b>Name:</b> Syndicate Loyalty Implant<BR>
+<b>Life:</b> Single use<BR>
+<b>Important Notes:</b> <font color='red'>Illegal</font><BR>
+<HR>
+<b>Implant Details:</b> <BR>
+<b>Function:</b> Makes the injected a slave to the owner of the implant.<HR>"}
+	return dat
+
+/obj/item/implant/mindslave/implant(mob/source, var/mob/user)
+
+	if(!source.mind)
+		to_chat(user.mind, "<span class='notice'>[source] doesn't posses the mental capabilities to be a slave.</span>")
+		return 0
+
+	var/mob/living/carbon/human/target = source.mind.current
+	var/mob/living/carbon/human/holder = user.mind.current
+
+	if(target == holder)
+		to_chat(holder, "<span class='notice'>You can't implant yourself!</span>")
+		return 0
+
+	var/obj/item/implant/mindslave/imp = locate(src.type) in source
+	if(imp)
+		to_chat(holder, "<span class='warning'>[target] is already a slave!</span>")
+		return 0
+
+	if(target.isloyal())
+		to_chat(holder, "<span class='warning'>[target] seems to resist the implant!</span>")
+		return 0
+
+	to_chat(target, "<span class='userdanger'><FONT size = 3>You feel a strange urge to serve [holder.real_name]. A simple thought about disobeying his/her commands makes your head feel like it is going to explode. You feel like you dont want to know what will happen if you actually disobey your new master.</FONT></span>")
+
+	var/datum/objective/mindslave/serve_objective = new
+	serve_objective.owner = target
+	serve_objective.explanation_text = "Serve [holder.real_name] no matter what!"
+	serve_objective.completed = 1
+	source.mind.objectives += serve_objective
+	if(!SSticker.mode.traitors.Find(source.mind))
+		SSticker.mode.traitors += source.mind
+
+	log_game("[holder.ckey] enslaved [target.ckey] with a Mindslave implant")
+
+	return ..()
+
+/obj/item/implant/mindslave/removed(mob/target)
+	if(..())
+
+		for(var/datum/objective/mindslave/objective in target.mind.objectives)
+			target.mind.objectives -= objective
+
+		if(target.mind.objectives.len == 0)
+			SSticker.mode.traitors -= target.mind
+
+		if(target.stat != DEAD)
+			target.visible_message("<span class='notice'>[target] looks like they have just been released from slavery!</span>", "<span class='boldnotice'>You feel as if you have just been released from eternal slavery. Yet you cant seem to remember anything at all!</span>")
+		return 1
+
+/obj/item/implanter/mindslave
+	name = "implanter (freedom)"
+
+/obj/item/implanter/mindslave/New()
+	imp = new /obj/item/implant/mindslave(src)
+	..()
+
+/datum/objective/mindslave
+	martyr_compatible = 1

--- a/outerhaven.dme
+++ b/outerhaven.dme
@@ -2342,6 +2342,7 @@
 #include "code\modules\zombie\items.dm"
 #include "code\modules\zombie\organs.dm"
 #include "haven\code\init.dm"
+#include "haven\code\game\objects\items\implants\implant_mindslave.dm"
 #include "haven\code\game\objects\structures\crates_lockers\closets\wardrobe.dm"
 #include "haven\code\modules\clothing\under\polychromic_clothes.dm"
 #include "interface\interface.dm"


### PR DESCRIPTION
Adds the mindslave implant, at a cost of 12 TC. When used, the mindslave implant will give the implantee an objective to serve the implanter. I haven't ported the cartridge bit, but everything else is from this PR: https://github.com/yogstation13/yogstation/pull/26

:cl:
add: Syndicate Agents can now buy mindslave implants!
/:cl:

[why]: # This was on the portlist, so I ported it.
