### PR TITLE
Moves rad collectors

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -44627,6 +44627,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ccW" = (
@@ -44647,6 +44650,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "ccY" = (
@@ -44656,14 +44662,23 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "ccZ" = (
 /obj/structure/particle_accelerator/end_cap,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cda" = (
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cdb" = (
@@ -44678,6 +44693,9 @@
 "cdc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -45129,14 +45147,16 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cet" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "Singularity";
 	name = "radiation shutters"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
-/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "ceu" = (
@@ -46203,10 +46223,6 @@
 "chQ" = (
 /obj/structure/window/plasma/reinforced{
 	dir = 4
-	},
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
@@ -51133,10 +51149,6 @@
 /obj/structure/window/plasma/reinforced{
 	dir = 8
 	},
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cBT" = (
@@ -51281,6 +51293,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/power/rad_collector/anchored,
+/obj/structure/cable/yellow,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cCJ" = (
@@ -51356,6 +51370,143 @@
 /obj/machinery/vending/games,
 /turf/open/floor/plasteel/dark,
 /area/library)
+"cCX" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Singularity";
+	name = "radiation shutters"
+	},
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"cCY" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cCZ" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Singularity";
+	name = "radiation shutters"
+	},
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"cDa" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/yellow/side,
+/area/engine/engineering)
+"cDb" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/yellow/side,
+/area/engine/engineering)
+"cDc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Singularity";
+	name = "radiation shutters"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cDd" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Singularity";
+	name = "radiation shutters"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cDe" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Singularity";
+	name = "radiation shutters"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cDf" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Singularity";
+	name = "radiation shutters"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cDg" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cDh" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cDi" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cDj" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cDk" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cDl" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 
 (1,1,1) = {"
 aaa
@@ -81085,16 +81236,16 @@ cam
 cdQ
 cet
 cCI
-cfV
+cDg
 cfU
 cgu
 cgU
 chw
-cBR
+cgU
 chw
+cgU
 chw
-chw
-chw
+cgU
 cjs
 cfV
 cfV
@@ -81338,11 +81489,11 @@ bZA
 cam
 cam
 cam
-cam
-cdQ
-cet
+ccT
+cDa
+cDc
 cCI
-cfV
+cDh
 cfV
 cgv
 cfV
@@ -81597,9 +81748,9 @@ cbi
 ccc
 ccV
 cdR
-cet
+cDd
 cCI
-cfV
+cDi
 cfU
 cgv
 cgV
@@ -81852,7 +82003,7 @@ bZA
 cao
 cbj
 bXk
-ccW
+cCX
 bXk
 bXk
 cfa
@@ -83137,7 +83288,7 @@ bZF
 cat
 bXk
 ccg
-cey
+cCY
 cdW
 cey
 cey
@@ -83394,7 +83545,7 @@ bZA
 cau
 cbj
 bXk
-ccW
+cCZ
 bXk
 bXk
 cfa
@@ -83655,7 +83806,7 @@ cdc
 cdX
 cet
 cCI
-cfV
+cDj
 cfU
 cgv
 cgV
@@ -83908,11 +84059,11 @@ bZA
 cam
 cam
 cam
-cam
-cdQ
-cet
+cde
+cDb
+cDe
 cCI
-cfV
+cDk
 cfV
 cgv
 cfV
@@ -84167,18 +84318,18 @@ cbm
 cci
 cam
 cdQ
-cet
+cDf
 cCI
-cfV
+cDl
 cfU
 cgx
 cgU
 chA
+cgU
 chA
+cgU
 chA
-chA
-chA
-chA
+cgU
 cjt
 cfV
 cfV


### PR DESCRIPTION
Moves the rad collectors and windows to the engine, so the rad collectors don't get shocked and blow up by a default setup.

Before:
![image](https://user-images.githubusercontent.com/20558591/34093591-5f6673bc-e3c9-11e7-885c-91b6a7e1de2a.png)

Now:
![image](https://user-images.githubusercontent.com/20558591/34093579-5149e5de-e3c9-11e7-8b92-ec3b1bef5d88.png)


:cl: optional name here
tweak: the engine room has been rearranged. Rad collectors were moved to the engineering room, and the room itself expanded.
/:cl:
